### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,13 @@ as defined in [RFC 6763](http://tools.ietf.org/html/rfc6763).
 Once [installed](#install), you can use the following code to look up the address of a local domain name:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $resolver = $factory->createResolver();
 
 $resolver->lookup('hostname.local')->then(function ($ip) {
    echo 'Found: ' . $ip . PHP_EOL;
 });
 
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -52,11 +50,9 @@ See also the [examples](examples).
 ### Factory
 
 The `Factory` is responsible for creating your [`Resolver`](#resolver) instance.
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 ```
 
 #### createResolver()
@@ -106,14 +102,13 @@ The resulting blocking code could look something like this:
 ```php
 use Clue\React\Block;
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $resolver = $factory->createResolver();
 
 $promise = $resolver->lookup('me.local');
 
 try {
-    $ip = Block\await($promise, $loop);
+    $ip = Block\await($promise);
     // IP successfully resolved
 } catch (Exception $e) {
     // an error occured while performing the request
@@ -128,7 +123,7 @@ $promises = array(
     $resolver->lookup('second.local'),
 );
 
-$ips = Block\awaitAll($promises, $loop);
+$ips = Block\awaitAll($promises);
 ```
 
 Please refer to [clue/reactphp-block](https://github.com/clue/reactphp-block#readme) for more details.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3",
         "clue/multicast-react": "^1.0 || ^0.2",
         "react/dns": "~0.4.0|~0.3.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.1 || ^1.2.1"
     },
     "require-dev": {

--- a/examples/lookup.php
+++ b/examples/lookup.php
@@ -4,8 +4,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $name = isset($argv[1]) ? $argv[1] : 'me.local';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Clue\React\Mdns\Factory($loop);
+$factory = new Clue\React\Mdns\Factory();
 $mdns = $factory->createResolver();
 
 $mdns->resolve($name)->then('e', 'e');

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,6 +2,7 @@
 
 namespace Clue\React\Mdns;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Dns\Query\ExecutorInterface;
 use React\Dns\Resolver\Resolver;
@@ -13,13 +14,13 @@ class Factory
     private $loop;
     private $executor;
 
-    public function __construct(LoopInterface $loop, ExecutorInterface $executor = null)
+    public function __construct(LoopInterface $loop = null, ExecutorInterface $executor = null)
     {
         if ($executor === null) {
             $executor = new MulticastExecutor($loop);
         }
 
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
         $this->executor = $executor;
     }
 

--- a/src/MulticastExecutor.php
+++ b/src/MulticastExecutor.php
@@ -6,6 +6,7 @@ use React\Dns\BadServerException;
 use React\Dns\Model\Message;
 use React\Dns\Protocol\Parser;
 use React\Dns\Protocol\BinaryDumper;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use Clue\React\Multicast\Factory as DatagramFactory;
@@ -27,8 +28,10 @@ class MulticastExecutor implements ExecutorInterface
     private $timeout;
     private $factory;
 
-    public function __construct(LoopInterface $loop, Parser $parser = null, BinaryDumper $dumper = null, $timeout = 5, DatagramFactory $factory = null)
+    public function __construct(LoopInterface $loop = null, Parser $parser = null, BinaryDumper $dumper = null, $timeout = 5, DatagramFactory $factory = null)
     {
+        $this->loop = $loop ?: Loop::get();
+
         if ($parser === null) {
             $parser = new Parser();
         }
@@ -36,10 +39,9 @@ class MulticastExecutor implements ExecutorInterface
             $dumper = new BinaryDumper();
         }
         if ($factory === null) {
-            $factory = new DatagramFactory($loop);
+            $factory = new DatagramFactory($this->loop);
         }
 
-        $this->loop = $loop;
         $this->parser = $parser;
         $this->dumper = $dumper;
         $this->timeout = $timeout;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -15,4 +15,15 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
     }
+
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Factory();
+
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
 }

--- a/tests/MulticastExecutorTest.php
+++ b/tests/MulticastExecutorTest.php
@@ -31,6 +31,17 @@ class MulticastExecutorTest extends TestCase
         $this->assertInstanceOf('React\Promise\PromiseInterface', $ret);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $executor = new MulticastExecutor();
+        
+        $ref = new \ReflectionProperty($executor, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($executor);
+        
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testCancellingPromiseWillCloseSocketAndReject()
     {
         $nameserver = Factory::DNS;


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229, reactphp/event-loop#231, reactphp/event-loop#232.