### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,12 @@ as defined in [RFC 6763](http://tools.ietf.org/html/rfc6763).
 Once [installed](#install), you can use the following code to look up the address of a local domain name:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $resolver = $factory->createResolver();
 
 $resolver->lookup('hostname.local')->then(function ($ip) {
    echo 'Found: ' . $ip . PHP_EOL;
 });
-
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -52,12 +49,16 @@ See also the [examples](examples).
 ### Factory
 
 The `Factory` is responsible for creating your [`Resolver`](#resolver) instance.
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 ```
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
 
 #### createResolver()
 
@@ -106,8 +107,7 @@ The resulting blocking code could look something like this:
 ```php
 use Clue\React\Block;
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $resolver = $factory->createResolver();
 
 $promise = $resolver->lookup('me.local');

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3",
         "clue/multicast-react": "^1.0 || ^0.2",
         "react/dns": "~0.4.0|~0.3.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.1 || ^1.2.1"
     },
     "require-dev": {

--- a/examples/lookup.php
+++ b/examples/lookup.php
@@ -4,8 +4,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $name = isset($argv[1]) ? $argv[1] : 'me.local';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Clue\React\Mdns\Factory($loop);
+$factory = new Clue\React\Mdns\Factory();
 $mdns = $factory->createResolver();
 
 $mdns->resolve($name)->then('e', 'e');
@@ -13,5 +12,3 @@ $mdns->resolve($name)->then('e', 'e');
 function e($v) {
     echo $v . PHP_EOL;
 }
-
-$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,6 +2,7 @@
 
 namespace Clue\React\Mdns;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Dns\Query\ExecutorInterface;
 use React\Dns\Resolver\Resolver;
@@ -10,17 +11,20 @@ class Factory
 {
     const DNS = '224.0.0.251:5353';
 
+    /** @var LoopInterface */
     private $loop;
+
+    /** @var ExecutorInterface */
     private $executor;
 
-    public function __construct(LoopInterface $loop, ExecutorInterface $executor = null)
+    /**
+     * @param ?LoopInterface $loop
+     * @param ?ExecutorInterface $executor
+     */
+    public function __construct(LoopInterface $loop = null, ExecutorInterface $executor = null)
     {
-        if ($executor === null) {
-            $executor = new MulticastExecutor($loop);
-        }
-
-        $this->loop = $loop;
-        $this->executor = $executor;
+        $this->loop = $loop ?: Loop::get();
+        $this->executor = $executor ?: new MulticastExecutor($loop);
     }
 
     public function createResolver()

--- a/src/MulticastExecutor.php
+++ b/src/MulticastExecutor.php
@@ -6,6 +6,7 @@ use React\Dns\BadServerException;
 use React\Dns\Model\Message;
 use React\Dns\Protocol\Parser;
 use React\Dns\Protocol\BinaryDumper;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use Clue\React\Multicast\Factory as DatagramFactory;
@@ -21,29 +22,35 @@ use React\Dns\Query\TimeoutException;
  */
 class MulticastExecutor implements ExecutorInterface
 {
+    /** @var LoopInterface */
     private $loop;
+
+    /** @var Parser */
     private $parser;
+
+    /** @var BinaryDumper */
     private $dumper;
+
+    /** @var number */
     private $timeout;
+
+    /** @var DatagramFactory */
     private $factory;
 
-    public function __construct(LoopInterface $loop, Parser $parser = null, BinaryDumper $dumper = null, $timeout = 5, DatagramFactory $factory = null)
+    /**
+     * @param ?LoopInterface $loop
+     * @param ?Parser $parser
+     * @param ?BinaryDumper $dumper
+     * @param number $timeout
+     * @param ?DatagramFactory $factory
+     */
+    public function __construct(LoopInterface $loop = null, Parser $parser = null, BinaryDumper $dumper = null, $timeout = 5, DatagramFactory $factory = null)
     {
-        if ($parser === null) {
-            $parser = new Parser();
-        }
-        if ($dumper === null) {
-            $dumper = new BinaryDumper();
-        }
-        if ($factory === null) {
-            $factory = new DatagramFactory($loop);
-        }
-
-        $this->loop = $loop;
-        $this->parser = $parser;
-        $this->dumper = $dumper;
+        $this->loop = $loop ?: Loop::get();
+        $this->parser = $parser ?: new Parser();
+        $this->dumper = $dumper ?: new BinaryDumper();
         $this->timeout = $timeout;
-        $this->factory = $factory;
+        $this->factory = $factory ?: new DatagramFactory($this->loop);
     }
 
     public function query($nameserver, Query $query)

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -15,4 +15,15 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('React\Dns\Resolver\Resolver', $resolver);
     }
+
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Factory();
+
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
 }

--- a/tests/MulticastExecutorTest.php
+++ b/tests/MulticastExecutorTest.php
@@ -31,6 +31,17 @@ class MulticastExecutorTest extends TestCase
         $this->assertInstanceOf('React\Promise\PromiseInterface', $ret);
     }
 
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $executor = new MulticastExecutor();
+        
+        $ref = new \ReflectionProperty($executor, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($executor);
+        
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     public function testCancellingPromiseWillCloseSocketAndReject()
     {
         $nameserver = Factory::DNS;


### PR DESCRIPTION
This pull request is a follow up for #16. Thanks to @PaulRotmann  for investing time into this :+1:.

This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$factory = new Clue\React\Mdns\Factory($loop);

// new (using default loop)
$factory = new Clue\React\Mdns\Factory();
```
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229 and reactphp/event-loop#232.

Resolves and Closes #16.